### PR TITLE
browser: handle urls with ambersand

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -19,7 +19,7 @@ class Browser:
             datasocket.onCommandReceived.append(self.onCommandReceived)
             datasocket.onBrowserClosed.append(self.onBrowserClosed)
             container = eConsoleAppContainer()
-            container.execute("/usr/bin/openhbbtvbrowser %s --onid %d --tsid %d --sid %d" % (url, onid, tsid, sid))
+            container.execute("/usr/bin/openhbbtvbrowser '%s' --onid %d --tsid %d --sid %d" % (url, onid, tsid, sid))
 
     def stop(self):
         if self.commandserver:


### PR DESCRIPTION
Use single quotes on url in order to espace url with ambersand.

This commit fixes url like http://hbbtv.ert.gr/start.php?s=erthd&r=504

The openhbbtv browser was misisng the &r=504 and onid/tsid/sid parameters
most probably causing other side effects as well.